### PR TITLE
Rename dashboard settings route names

### DIFF
--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -7,12 +7,12 @@ use Inertia\Inertia;
 Route::get('/', fn () => Inertia::render('dashboard/index'))->name('dashboard');
 
 Route::group(['prefix' => '/settings'], function () {
-    Route::get('/', fn () => Inertia::render('settings/profile/index'))->name('dashboard.contacts.index');
-    Route::get('/account', fn () => Inertia::render('settings/account/index'))->name('dashboard.contacts.accoubt');
-    Route::get('/appearance', fn () => Inertia::render('settings/appearance/index'))->name('dashboard.file-manager.index');
-    Route::get('/display', fn () => Inertia::render('settings/display/index'))->name('dashboard.notes.index');
-    Route::get('/notifications', fn () => Inertia::render('settings/notifications/index'))->name('dashboard.scrumboard.index');
-    Route::get('/profile', fn () => Inertia::render('settings/profile/index'))->name('dashboard.todo.index');
+    Route::get('/', fn () => Inertia::render('settings/profile/index'))->name('dashboard.settings.index');
+    Route::get('/account', fn () => Inertia::render('settings/account/index'))->name('dashboard.settings.account');
+    Route::get('/appearance', fn () => Inertia::render('settings/appearance/index'))->name('dashboard.settings.appearance');
+    Route::get('/display', fn () => Inertia::render('settings/display/index'))->name('dashboard.settings.display');
+    Route::get('/notifications', fn () => Inertia::render('settings/notifications/index'))->name('dashboard.settings.notifications');
+    Route::get('/profile', fn () => Inertia::render('settings/profile/index'))->name('dashboard.settings.profile');
 });
 
 Route::get('/apps', fn () => Inertia::render('apps/index'))->name('dashboard.apps');


### PR DESCRIPTION
## Summary
- rename dashboard setting routes to use descriptive names

## Testing
- `npm test` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68409aceebb48328a6082f340a4c0011