### PR TITLE
Add guest dashboard redirect test

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,8 +25,10 @@ Route::get('/500', fn () => Inertia::render('errors/general-error'));
 Route::get('/503', fn () => Inertia::render('errors/maintenance-error'));
 Route::get('/pricing', fn () => Inertia::render('pricing/index'));
 
-Route::group(['prefix' => '/dashboard'], function () {
-    require __DIR__.'/dashboard.php';
-})->middleware(['auth', 'verified']);
+Route::middleware(['auth', 'verified'])
+    ->prefix('dashboard')
+    ->group(function () {
+        require __DIR__.'/dashboard.php';
+    });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/DashboardAccessTest.php
+++ b/tests/Feature/DashboardAccessTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class DashboardAccessTest extends TestCase
+{
+    /**
+     * Ensure guests are redirected from the dashboard.
+     */
+    public function test_guest_is_redirected_from_dashboard(): void
+    {
+        $response = $this->get('/dashboard');
+
+        $response->assertRedirect(route('login'));
+    }
+}


### PR DESCRIPTION
## Summary
- add feature test ensuring guest dashboard access redirects to login
- protect dashboard routes with auth middleware

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68409ace363c8328823f0f8232374002